### PR TITLE
removes jQuery as prerequisite:

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}

--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ element Y as the last element, then the behaviour of the caret is the following:
 
 ```bash
 npm install
-grunt build
-grunt karma:e2e
+bower install
+grunt
 ```

--- a/angular-contenteditable.js
+++ b/angular-contenteditable.js
@@ -53,7 +53,7 @@ angular.module('contenteditable', [])
           oldRender()
         }
         $element.html(ngModel.$viewValue || '')
-        el = $element.get(0)
+        el = $element[0]
         range = document.createRange()
         sel = window.getSelection()
         if (el.childNodes.length > 0) {
@@ -67,7 +67,7 @@ angular.module('contenteditable', [])
         sel.addRange(range)
       }
       if (attrs.selectNonEditable && attrs.selectNonEditable !== "false") {
-        $element.click(function(e) {
+        $element.bind('click', function(e) {
           var range, sel, target
           target = e.toElement
           if (target !== this && angular.element(target).attr('contenteditable') === 'false') {


### PR DESCRIPTION
- jQuery was used in two places in the code: a get() call and a click() call, both of which are unsupported by jqLite, but have workarounds.
- jQuery is still used for functional testing.
