### PR TITLE
Add attribute to strip all HTML from element

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ angular.module('myapp', ['contenteditable'])
   <span contenteditable="true"
         ng-model="model"
         strip-br="true"
+        strip-html="true"
         select-non-editable="true">
   </span>
 </div>

--- a/angular-contenteditable.js
+++ b/angular-contenteditable.js
@@ -21,6 +21,7 @@ angular.module('contenteditable', [])
         'noLineBreaks',
         'selectNonEditable',
         'moveCaretToEndOnChange',
+        'stripHtml',
       ], function(opt) {
         var o = attrs[opt]
         opts[opt] = o && o !== 'false'
@@ -41,6 +42,10 @@ angular.module('contenteditable', [])
               rerender = true
               html = html2
             }
+          }
+          if (opts.stripHtml) {
+            rerender = true
+            html = element.text()
           }
           ngModel.$setViewValue(html)
           if (rerender) {


### PR DESCRIPTION
I'm using `contenteditable` as a kind of glorified input box. I've found that it's often much easier and flexible to make a `li` or a `h1` editable and style it a little to hint editability than it is to insert regular input boxes. However in these cases I don't actually want the user the ability to insert HTML into the editable.

To support that use case this tiny patch adds a `strip-html` attribute that strips all HTML from the content of the editable element.
