### PR TITLE
Also rerender when stripping trailing br.

### DIFF
--- a/angular-contenteditable.js
+++ b/angular-contenteditable.js
@@ -33,7 +33,11 @@ angular.module('contenteditable', [])
           html = element.html()
           rerender = false
           if (opts.stripBr) {
-            html = html.replace(/<br>$/, '')
+            html2 = html.replace(/<br>$/, '')
+            if (html2 !== html) {
+              rerender = true
+              html = html2
+            }
           }
           if (opts.noLineBreaks) {
             html2 = html.replace(/<div>/g, '').replace(/<br>/g, '').replace(/<\/div>/g, '')


### PR DESCRIPTION
The current code does not rerender in this case. Because of that, you can leave trailing <br> in the DOM (even if the ng-model is clean). This is a problem for me since I rely on the contenteditable being empty to display the placeholder:

``` css
[contenteditable]:empty::before {
  content: attr(placeholder);
}
```
