### PR TITLE
Leave text unformatted

### DIFF
--- a/angular-contenteditable.js
+++ b/angular-contenteditable.js
@@ -65,6 +65,11 @@ angular.module('contenteditable', [])
         if (!!oldRender) {
           oldRender()
         }
+
+        if (opts.unformattedText) {
+          ngModel.$viewValue = ngModel.$viewValue.replace(new RegExp('\n','g'), '<br>');
+        }
+
         element.html(ngModel.$viewValue || '')
         if (opts.moveCaretToEndOnChange) {
           el = element[0]

--- a/angular-contenteditable.js
+++ b/angular-contenteditable.js
@@ -21,6 +21,7 @@ angular.module('contenteditable', [])
         'noLineBreaks',
         'selectNonEditable',
         'moveCaretToEndOnChange',
+        'unformattedText'
       ], function(opt) {
         var o = attrs[opt]
         opts[opt] = o && o !== 'false'
@@ -30,7 +31,7 @@ angular.module('contenteditable', [])
       element.bind('input', function(e) {
         scope.$apply(function() {
           var html, html2, rerender
-          html = element.html()
+          html = opts.unformattedText ? element[0].innerText : element.html()
           rerender = false
           if (opts.stripBr) {
             html = html.replace(/<br>$/, '')

--- a/test/e2e/scenarios.coffee
+++ b/test/e2e/scenarios.coffee
@@ -22,3 +22,12 @@ describe 'module contenteditable', ->
         expect(element('#input').html()).toBe 'a <span style="color:red">red</span> b'
         expect(element('#input span').html()).toBe 'red'
         expect(element('#output').html()).toBe 'a &lt;span style="color:red"&gt;red&lt;/span&gt; b'
+
+      it 'setting the model with some pure text should dispaly <br> instead of newlines \\n', ->
+        input('unformatted').enter('#h1\n\n##h2\n###h3');
+        expect(element('#output-unformatted').html()).toBe '#h1<br><br>##h2<br>###h3'
+
+      it 'putting some unformatted text with <br>s in the html should replace them with newlines', ->
+
+        element('#output-unformatted').html('#h1<br><br>##h2<br>###h3');
+        expect(input('unformatted').val()).toBe('#h1\n\n##h2\n###h3');

--- a/test/fixtures/simple.html
+++ b/test/fixtures/simple.html
@@ -34,6 +34,11 @@ angular.bootstrap(document, ['simple'])
       <hr>
       <label>Contenteditable without Model</label>
       <div contenteditable>Edit me - I don't affect anything</div>
+      <hr>
+      <label>Model has pure text</label>
+      <br>
+      <textarea id="inputUnformatted" ng-model="unformatted"></textarea>
+      <div id="output-unformatted" contenteditable="true" ng-model="unformatted" unformatted-text="true"></div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
Hello there,

I found useful to leave the text unformatted. Use case is as follow.

I want to use the contenteditable directive as an input field for a markdown document.

In such a scenario I will need the inserted text without html elements in the model but I will still need the <br>s in place of the newlines (\n) in the view. This last is the case where we update the model programmatically and we want to be displayed properly.